### PR TITLE
data: fixed columns order for lbeam_bluescope_equal

### DIFF
--- a/data/profile_l.blt
+++ b/data/profile_l.blt
@@ -44,7 +44,7 @@ classes:
       type: beam type
     free: [type, l]
     tables:
-      columns: [t, r1, r2, a]
+      columns: [a, t, r1, r2]
       data: !include profile_l/lbeam_bluescope_equal.yaml
       index: type
     types:


### PR DESCRIPTION
Fixed columns order for lbeam_bluescope_equal (https://github.com/boltsparts/boltsparts/blob/main/data/profile_l/lbeam_bluescope_equal.yaml).

(Not sure if it's intended) turned out the column order in .blt file was important when I was accessing bolts data using boltspy - if columns in .blt files don't match columns in .yml file then `bolt_class.parameters.tables[0].columns` and `bolt_class.parameters.tables[0].data` won't match too.