### PR TITLE
Remove duplicate `types` key in `hex_socket.blt` and `nice` in `hex.blt`

### DIFF
--- a/data/hex.blt
+++ b/data/hex.blt
@@ -237,7 +237,7 @@ classes:
           nice: ISO 4017
         labeling:
           nice: Hexagon head screw ISO 4017 %(key)s - %(l)s
-          nice: hexagon_head_screw_ISO4017_%(key)s_%(l)s
+          safe: hexagon_head_screw_ISO4017_%(key)s_%(l)s
         description: Hexagon head screw according to ISO4017
       - body: DINENISO
         standard:

--- a/data/hex_socket.blt
+++ b/data/hex_socket.blt
@@ -420,7 +420,6 @@ classes:
     parameters:
       free: [key,l,point]
       types:
-      types:
         key: Table Index
         l: Length (mm)
         d: Length (mm)


### PR DESCRIPTION
This broke parsing via automated tooling for me.