### PR TITLE
Remove duplicate `types` key in hex_socket.blt

### DIFF
--- a/data/hex_socket.blt
+++ b/data/hex_socket.blt
@@ -420,7 +420,6 @@ classes:
     parameters:
       free: [key,l,point]
       types:
-      types:
         key: Table Index
         l: Length (mm)
         d: Length (mm)


### PR DESCRIPTION
There was a duplicate `types` key on line 422 in the definition of `hexsocketsetscrewall` that stymies parsing by the Node `yaml` library.

This commit removes the duplicate definition.