### PR TITLE
hexbolt2 section has duplicate "nice" keys.

### DIFF
--- a/data/hex.blt
+++ b/data/hex.blt
@@ -237,7 +237,7 @@ classes:
           nice: ISO 4017
         labeling:
           nice: Hexagon head screw ISO 4017 %(key)s - %(l)s
-          nice: hexagon_head_screw_ISO4017_%(key)s_%(l)s
+          safe: hexagon_head_screw_ISO4017_%(key)s_%(l)s
         description: Hexagon head screw according to ISO4017
       - body: DINENISO
         standard:


### PR DESCRIPTION
The standard definition section for the ISO body in the hexbolt2 info has two `nice` keys, the second of which (by comparison to the other sections) should be a `safe` key.

This commit changes the second field to have the `safe` key.